### PR TITLE
feat: add remote image option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 npm-debug.log
 named_modifiers.json
 test/sample_images/dont-version*
+package-lock.json

--- a/src/image.js
+++ b/src/image.js
@@ -135,12 +135,16 @@ Image.prototype.getFile = function(project){
   // look to see if the request has a specified source
   if (_.has(this.modifiers, 'external')){
     if (_.has(sources, this.modifiers.external)){
-      streamType = this.modifiers.external;
+			streamType = this.modifiers.external;
     } else if (_.has(env.externalSources, this.modifiers.external)) {
-      Stream = sources.external;
+			Stream = sources.external;
       return new Stream(this, this.modifiers.external, env.externalSources[this.modifiers.external]);
     }
   }
+	if(_.has(this.modifiers, 'remote')) {
+		Stream = sources.remote;
+		return new Stream(this, project);
+	}
 
   // if this request is for an excluded source create an ErrorStream
   if (excludes.indexOf(streamType) > -1){

--- a/src/lib/modifiers.js
+++ b/src/lib/modifiers.js
@@ -111,6 +111,11 @@ modifierMap = [
     default: environment.DEFAULT_SOURCE
   },
   {
+    key: 'r',
+    desc: 'remote',
+    type: 'string'
+  },
+  {
     key: 'f',
     desc: 'filter',
     type: 'string',
@@ -172,7 +177,7 @@ function parseModifiers(mods, modArr) {
 
       //this is a limit enforced by sharp. the application will crash without
       //these checks.
-      var dimensionLimit = 16383;
+			var dimensionLimit = 16383;
 
       switch(mod.desc){
       case 'height':
@@ -218,10 +223,14 @@ function parseModifiers(mods, modArr) {
         mods.hasModStr = true;
         break;
       case 'external':
-        value = string.sanitize(value, 'alphanumeric');
+				value = string.sanitize(value, 'alphanumeric');
         if (inArray(value.toLowerCase(), mod.values)){
           mods.external = value.toLowerCase();
         }
+        mods.hasModStr = true;
+        break;
+			case 'remote':
+				mods.remote = true;
         mods.hasModStr = true;
         break;
       case 'filter':
@@ -336,20 +345,20 @@ exports.parse = function(requestUrl, namedMods, envOverride){
   // only named modifiers.
   if (!env.NAMED_MODIFIERS_ONLY) {
     mods = parseModifiers(mods, modStr.split('-'));
-  }
+	}
 
 
   // check to see if this a metadata call, it trumps all other requested mods
   if (image.slice(-5) === '.json'){
     mods.action = 'json';
     return mods;
-  }
+	}
 
   if (mods.action === 'square'){
     // make sure crop is set to the default
     mods.crop = 'fill';
     return limitMaxDimension(mods, env);
-  }
+	}
 
   if (mods.height !== null || mods.width !== null){
     mods.action = 'resize';
@@ -363,7 +372,7 @@ exports.parse = function(requestUrl, namedMods, envOverride){
     if (_.has(mods, 'x') || _.has(mods, 'y')) {
       mods.action = 'crop';
     }
-  }
+	}
 
   return limitMaxDimension(mods, env);
 };

--- a/src/streams/sources/remote.js
+++ b/src/streams/sources/remote.js
@@ -1,0 +1,75 @@
+'use strict';
+
+var stream, util, request, env;
+
+stream  = require('stream');
+util    = require('util');
+request = require('request');
+env     = require('../../config/environment_vars');
+
+
+function Remote(image){
+  /* jshint validthis:true */
+  if (!(this instanceof Remote)){
+    return new Remote(image);
+  }
+  stream.Readable.call(this, { objectMode : true });
+  this.image = image;
+  this.ended = false;
+
+  // set the expiry value to the shorter value
+  this.image.expiry = env.IMAGE_EXPIRY_SHORT;
+}
+
+util.inherits(Remote, stream.Readable);
+
+Remote.prototype._read = function(){
+  var _this = this,
+      url;
+
+  if ( this.ended ){ return; }
+
+  // pass through if there is an error on the image object
+  if (this.image.isError()){
+    this.ended = true;
+    this.push(this.image);
+    return this.push(null);
+	}
+	url = decodeURIComponent(this.image.path);
+
+  this.image.log.time('source:Remote');
+
+  var opts = {
+    url: url,
+    encoding: null,
+    headers: {
+      'User-Agent': env.USER_AGENT
+    }
+  };
+
+  request(opts, function (err, response, body) {
+    _this.image.log.timeEnd('source:Remote');
+
+    if (err) {
+      _this.image.error = err;
+    }
+    else {
+      if (response.statusCode === 200) {
+        _this.image.contents = body;
+        _this.image.originalContentLength = body.length;
+        _this.ended = true;
+      }
+      else {
+        _this.image.error = new Error('Remote user image not found');
+        _this.image.error.statusCode = 404;
+      }
+    }
+
+    _this.push(_this.image);
+    _this.push(null);
+  });
+
+};
+
+
+module.exports = Remote;


### PR DESCRIPTION
Remote image support was possible with the `-e` param, but you have to provide each external resource via .env. The new `-r` option allows to use url encoded images from any server.

Beware: Limiting the access is recommendable.